### PR TITLE
Render new LAD columns (annotations and shared notes)

### DIFF
--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -244,6 +244,12 @@ class UsersTable extends React.Component {
             <th className="px-3.5 2xl:px-4 py-3 text-center">
               <FormattedMessage id="app.learningDashboard.usersTable.colRaiseHands" defaultMessage="Raise Hand" />
             </th>
+            <th className="px-3.5 2xl:px-4 py-3 text-center">
+              <FormattedMessage id="app.learningDashboard.usersTable.colTotalOfWhiteboardAnnotations" defaultMessage="Whiteboard Annotations" />
+            </th>
+            <th className="px-3.5 2xl:px-4 py-3 text-center">
+              <FormattedMessage id="app.learningDashboard.usersTable.colTotalOfSharedNotes" defaultMessage="Shared Notes" />
+            </th>
             <th
               className={`px-3.5 2xl:px-4 py-3 text-center ${tab === 'overview_activityscore' ? 'cursor-pointer' : ''}`}
               onClick={() => { if (tab === 'overview_activityscore') this.toggleOrder('activityScoreOrder'); }}
@@ -480,6 +486,22 @@ class UsersTable extends React.Component {
                             ✋
                             &nbsp;
                             {user.raiseHand.length}
+                          </span>
+                        ) : null }
+                    </td>
+                    <td className={`px-4 py-3 text-sm text-center ${opacity}`} data-test="userTotalOfWhiteboardAnnotationsDashboard">
+                      { user.totalOfWhiteboardAnnotations > 0
+                        ? (
+                          <span>
+                            {user.totalOfWhiteboardAnnotations}
+                          </span>
+                        ) : null }
+                    </td>
+                    <td className={`px-4 py-3 text-sm text-center ${opacity}`} data-test="userTotalOfSharedNotesDashboard">
+                      { user.totalOfSharedNotes > 0
+                        ? (
+                          <span>
+                            {user.totalOfSharedNotes}
                           </span>
                         ) : null }
                     </td>

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -221,34 +221,69 @@ class UsersTable extends React.Component {
               className={`px-3.5 2xl:px-4 py-3 text-center ${tab === 'overview' ? 'cursor-pointer' : ''}`}
               onClick={() => { if (tab === 'overview') this.toggleOrder('talkTimeOrder'); }}
             >
-              <FormattedMessage id="app.learningDashboard.usersTable.colTalk" defaultMessage="Talk time" />
-              { tab === 'overview' && lastFieldClicked === 'talkTimeOrder'
-                ? renderArrow(talkTimeOrder)
-                : null }
+              <span className="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z" />
+                </svg>
+                <FormattedMessage id="app.learningDashboard.usersTable.colTalk" defaultMessage="Talk time" />
+                { tab === 'overview' && lastFieldClicked === 'talkTimeOrder'
+                  ? renderArrow(talkTimeOrder)
+                  : null }
+              </span>
             </th>
             <th
               className={`px-3.5 2xl:px-4 py-3 text-center ${tab === 'overview' ? 'cursor-pointer' : ''}`}
               onClick={() => { if (tab === 'overview') this.toggleOrder('webcamTimeOrder'); }}
             >
-              <FormattedMessage id="app.learningDashboard.usersTable.colWebcam" defaultMessage="Webcam Time" />
-              { tab === 'overview' && lastFieldClicked === 'webcamTimeOrder'
-                ? renderArrow(webcamTimeOrder)
-                : null }
+              <span className="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z" />
+                </svg>
+                <FormattedMessage id="app.learningDashboard.usersTable.colWebcam" defaultMessage="Webcam Time" />
+                { tab === 'overview' && lastFieldClicked === 'webcamTimeOrder'
+                  ? renderArrow(webcamTimeOrder)
+                  : null }
+              </span>
             </th>
             <th className="px-3.5 2xl:px-4 py-3 text-center">
-              <FormattedMessage id="app.learningDashboard.usersTable.colMessages" defaultMessage="Messages" />
+              <span className="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
+                </svg>
+                <FormattedMessage id="app.learningDashboard.usersTable.colMessages" defaultMessage="Messages" />
+              </span>
             </th>
             <th className="px-3.5 2xl:px-4 py-3 col-text-left">
-              <FormattedMessage id="app.learningDashboard.usersTable.colReactions" defaultMessage="Reactions" />
+              <span className="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+                </svg>
+                <FormattedMessage id="app.learningDashboard.usersTable.colReactions" defaultMessage="Reactions" />
+              </span>
             </th>
             <th className="px-3.5 2xl:px-4 py-3 text-center">
-              <FormattedMessage id="app.learningDashboard.usersTable.colRaiseHands" defaultMessage="Raise Hand" />
+              <span className="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M10.05 4.575a1.575 1.575 0 1 0-3.15 0v3m3.15-3v-1.5a1.575 1.575 0 0 1 3.15 0v1.5m-3.15 0 .075 5.925m3.075.75V4.575m0 0a1.575 1.575 0 0 1 3.15 0V15M6.9 7.575a1.575 1.575 0 1 0-3.15 0v8.175a6.75 6.75 0 0 0 6.75 6.75h2.018a5.25 5.25 0 0 0 3.712-1.538l1.732-1.732a5.25 5.25 0 0 0 1.538-3.712l.003-2.024a.668.668 0 0 1 .198-.471 1.575 1.575 0 1 0-2.228-2.228 3.818 3.818 0 0 0-1.12 2.687M6.9 7.575V12m6.27 4.318A4.49 4.49 0 0 1 16.35 15m.002 0h-.002" />
+                </svg>
+                <FormattedMessage id="app.learningDashboard.usersTable.colRaiseHands" defaultMessage="Raise Hand" />
+              </span>
             </th>
             <th className="px-3.5 2xl:px-4 py-3 text-center">
-              <FormattedMessage id="app.learningDashboard.usersTable.colTotalOfWhiteboardAnnotations" defaultMessage="Whiteboard Annotations" />
+              <span className="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+                </svg>
+                <FormattedMessage id="app.learningDashboard.usersTable.colTotalOfWhiteboardAnnotations" defaultMessage="Whiteboard Annotations" />
+              </span>
             </th>
             <th className="px-3.5 2xl:px-4 py-3 text-center">
-              <FormattedMessage id="app.learningDashboard.usersTable.colTotalOfSharedNotes" defaultMessage="Shared Notes" />
+              <span className="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+                </svg>
+                <FormattedMessage id="app.learningDashboard.usersTable.colTotalOfSharedNotes" defaultMessage="Shared Notes" />
+              </span>
             </th>
             <th
               className={`px-3.5 2xl:px-4 py-3 text-center ${tab === 'overview_activityscore' ? 'cursor-pointer' : ''}`}


### PR DESCRIPTION
Renders new LAD columns (annotations and shared notes) and add table header icons.

<img width="1852" height="952" alt="Screenshot from 2025-10-23 17-32-17" src="https://github.com/user-attachments/assets/82f43ccd-c0d9-4748-afb5-f91c6b79c4b3" />
